### PR TITLE
V1.1.3

### DIFF
--- a/g2t.py
+++ b/g2t.py
@@ -217,11 +217,11 @@ def get_nirvana_data_dict(
 
                     if hgnc_id is None:
                         hgnc_id, ensg_id = assign_ids_to_symbol(
-                            gff_gene_name, hgnc_data, symbols_data
+                            gff_gene_name, symbols_data
                         )
                 else:
                     hgnc_id, ensg_id = assign_ids_to_symbol(
-                        gff_gene_name, hgnc_data, symbols_data
+                        gff_gene_name, symbols_data
                     )
 
                 if hgnc_id is None:
@@ -248,7 +248,7 @@ def get_nirvana_data_dict(
 
 
 def assign_ids_to_symbol(
-    gene_symbol: str, hgnc_data: dict, symbols_data: list
+    gene_symbol: str, symbols_data: list
 ):
     """ Get the hgnc and ensg ids from a gene symbol
 
@@ -275,9 +275,9 @@ def assign_ids_to_symbol(
     if amount_symbol_in_data > 1:
         return f"{gene_symbol}_hgnc_id_TBD", f"{gene_symbol}_ensg_id_TBD"
 
-    if gene_symbol in hgnc_data:
-        hgnc_id = hgnc_data[gene_symbol]["hgnc_id"]
-        ensg_id = hgnc_data[gene_symbol]["ensg_id"]
+    if gene_symbol in symbol_dict:
+        hgnc_id = symbol_dict[gene_symbol]["hgnc_id"]
+        ensg_id = symbol_dict[gene_symbol]["ensg_id"]
     elif gene_symbol in alias_data:
         hgnc_id = alias_data[gene_symbol]["hgnc_id"]
         ensg_id = alias_data[gene_symbol]["ensg_id"]
@@ -722,9 +722,7 @@ def main(**args):
         for gene in genes:
             # if given gene symbols, try to assign hgnc ids
             if not gene.startswith("HGNC:"):
-                hgnc_id, ensg_id = assign_ids_to_symbol(
-                    gene, hgnc_data, symbols_data
-                )
+                hgnc_id, ensg_id = assign_ids_to_symbol(gene, symbols_data)
 
                 # the assign_ids_to_symbol function can give a _TBD tag if the
                 # gene symbol was ambiguous to assign to a hgnc id
@@ -735,7 +733,7 @@ def main(**args):
                     )
                     print(msg)
                     logger.warning(msg)
-                    current_g2t.append(f"{gene}\t\t\t\n")
+                    current_g2t.append(f"{gene}\t\t\tto_review\n")
             else:
                 hgnc_id = gene
 

--- a/g2t.py
+++ b/g2t.py
@@ -254,7 +254,6 @@ def assign_ids_to_symbol(
 
     Args:
         gene_symbol (str): Gene symbol
-        hgnc_data (dict): Dict of hgnc data
         symbols_data (list): List of symbol data (alias data, previous data..)
 
     Returns:


### PR DESCRIPTION
# BUG FIX:
- `assign_ids_to_symbol` was broken and did not work properly when looking for non alias and non previous symbols. This did not cause any issues previously because when generating the original g2t, panelapp panels already have hgnc ids and the few genes that had symbols in the test directory, I used the hgnc_queries package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/generate_g2t/7)
<!-- Reviewable:end -->
