### PR TITLE
Make --hgnc_dump optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To run this code, you need to have:
 
 - A MANE Select file downloaded from Ensembl http://tark.ensembl.org/web/mane_GRCh37_list/ (for build 37), or a MANE Select file from RefSeq https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/ (for build 38)
-- A HGNC dump downloaded from https://www.genenames.org/download/custom/ (default columns). This is not needed if a RefSeq MANE gff is being used.
+- A HGNC dump downloaded from https://www.genenames.org/download/custom/ (default columns). This is not needed if a RefSeq MANE gff is being used, because the HGNC IDs are included in the gff.
 - A local HGMD database
 
 DNAnexus has some HGMD dumps in dev projects. To setup the HGMD database:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ python main.py --hgnc_dump ${hgnc_dump} assign_transcripts -mane ${Ensembl_MANE_
 python main.py --hgnc_dump ${hgnc_dump} assign_transcripts -mane ${Ensembl_MANE_Select_file} -hgmd ${database_name} ${database_usr} ${database_pwd} -hgnc_file ${hgnc_file}
 
 # for build 38, RefSeq MANE gff
-python main.py --hgnc_dump ${hgnc_dump} assign_transcripts --mane_gff ${MANE_RefSeq_gff} -hgmd ${database_name} ${database_usr} ${database_pwd} -hgnc_ids ${hgnc_id} ${hgnc_id} ...
-python main.py --hgnc_dump ${hgnc_dump} assign_transcripts --mane_gff ${MANE_RefSeq_gff} -hgmd ${database_name} ${database_usr} ${database_pwd} -hgnc_file ${hgnc_file}
+python main.py assign_transcripts --mane_gff ${MANE_RefSeq_gff} -hgmd ${database_name} ${database_usr} ${database_pwd} -hgnc_ids ${hgnc_id} ${hgnc_id} ...
+python main.py assign_transcripts --mane_gff ${MANE_RefSeq_gff} -hgmd ${database_name} ${database_usr} ${database_pwd} -hgnc_file ${hgnc_file}
 ```
 
 By default, the output created by this script will be located `./YYMMDD_results`. If that folder already exists, a new folder will be created with an number to differentiate folders.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 To run this code, you need to have:
 
-- A HGNC dump downloaded from https://www.genenames.org/download/custom/ (default columns)
-- A MANE Select file downloaded from http://tark.ensembl.org/web/mane_GRCh37_list/ (for build 37), or a MANE Select file from https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/ (for build 38)
+- A MANE Select file downloaded from Ensembl http://tark.ensembl.org/web/mane_GRCh37_list/ (for build 37), or a MANE Select file from RefSeq https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/ (for build 38)
+- A HGNC dump downloaded from https://www.genenames.org/download/custom/ (default columns). This is not needed if a RefSeq MANE gff is being used.
 - A local HGMD database
 
 DNAnexus has some HGMD dumps in dev projects. To setup the HGMD database:

--- a/g2t_ops/transcript_assigner.py
+++ b/g2t_ops/transcript_assigner.py
@@ -257,7 +257,7 @@ def assign_transcripts(session, meta, mane_select_data, g2t_data, source) -> dic
     """
 
     data = {}
-    print("There are " + str(len(list(g2t_data.values()))))
+
     for gene, transcripts in g2t_data.items():
         data.setdefault(gene, {})
         data[gene].setdefault("no_clinical_transcript", [])

--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ from g2t_ops import convert_symbols, utils, transcript_assigner
 
 def main(args):
     output_path = utils.create_output_folder(args["output_folder"])
-    hgnc_dump = utils.parse_tsv(args["hgnc_dump"])
+
+    if args["hgnc_dump"]:
+        hgnc_dump = utils.parse_tsv(args["hgnc_dump"])
 
     if args["command"] == "convert_symbols":
         if args["symbols"]:
@@ -73,7 +75,7 @@ if __name__ == "__main__":
         help="Output folder in which to create the output files"
     )
     parser.add_argument(
-        "-hgnc_dump", "--hgnc_dump", required=True,
+        "-hgnc_dump", "--hgnc_dump", required=False,
         help="Path to HGNC dump downloaded from genenames.org"
     )
 


### PR DESCRIPTION
Make the input `--hgnc_dump` optional, as it is only needed if using MANE data from an Ensembl csv. The HGNC IDs are included in the RefSeq gff so the hgnc dump is not used when running g2t_ops with a refseq gff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/g2t_ops/13)
<!-- Reviewable:end -->
